### PR TITLE
perl-5.26.0-readiness.  Account for removal of '.' from default @INC.

### DIFF
--- a/t/01-Data-GUID-Any.t
+++ b/t/01-Data-GUID-Any.t
@@ -5,7 +5,8 @@ no warnings 'once';
 use Test::More 0.92;
 use Config;
 use File::Spec;
-use t::Util;
+use lib "./t";
+use Util;
 
 # Work around buffering that can show diags out of order
 Test::More->builder->failure_output(*STDOUT) if $ENV{HARNESS_VERBOSE};
@@ -76,13 +77,13 @@ for my $style ( qw/any v1 v4/ ) {
         "$style: Data::GUID::Any set to use '$mod'"
       );
       my $guid = $fcn{$style}->();
-      ok( t::Util::looks_like_uc_guid( $guid  ),
+      ok( Util::looks_like_uc_guid( $guid  ),
         "$style: got valid guid from '$mod'"
       ) or diag $guid;
       {
         local $Data::GUID::Any::UC;
         $guid = $fcn{$style}->();
-        ok( t::Util::looks_like_lc_guid( $guid  ),
+        ok( Util::looks_like_lc_guid( $guid  ),
           "$style: got valid lc guid from '$mod' (\$UC=0)"
         ) or diag $guid;
       }

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -1,4 +1,4 @@
-package t::Util;
+package Util;
 use strict;
 use warnings;
 use Exporter;


### PR DESCRIPTION
For: https://rt.cpan.org/Ticket/Display.html?id=121185